### PR TITLE
add plist to auto start apache

### DIFF
--- a/apache22.rb
+++ b/apache22.rb
@@ -27,4 +27,34 @@ class Apache22 < Formula
     # create logs directory
     Dir.mkdir "#{prefix}/logs" unless File.directory? "#{prefix}/logs"
   end
+
+  plist_options :manual => "sudo apachectl start"
+
+  def plist_startup
+    true
+  end
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <true/>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_prefix}/bin/httpd</string>
+        <string>-D</string>
+        <string>FORGROUND</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>SHAuthorizationRight</key>
+      <string>system.preferences</string>
+    </dict>
+    </plist>
+    EOS
+  end
 end

--- a/apache24.rb
+++ b/apache24.rb
@@ -41,4 +41,34 @@ class Apache24 < Formula
     # create logs directory
     Dir.mkdir "#{prefix}/logs" unless File.directory? "#{prefix}/logs"
   end
+
+  plist_options :manual => "sudo apachectl start"
+
+  def plist_startup
+    true
+  end
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <true/>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_prefix}/bin/httpd</string>
+        <string>-D</string>
+        <string>FORGROUND</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>SHAuthorizationRight</key>
+      <string>system.preferences</string>
+    </dict>
+    </plist>
+    EOS
+  end
 end


### PR DESCRIPTION
After installed apache24, apache server does not start automatically anymore.

This pull request adds plist to allow apache to start automatically at system startup.
